### PR TITLE
refactor(logger): update logger type and enhance setupLogger function

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ A modular, production-grade utility toolkit for Node.js and TypeScript, designed
   <img src="https://img.shields.io/node/v/@catbee/utils" alt="Node Version" />
   <img src="https://img.shields.io/npm/v/@catbee/utils" alt="NPM Version" />
   <img src="https://img.shields.io/npm/v/@catbee/utils/rc" alt="NPM RC Version" />
+  <img src="https://img.shields.io/npm/v/@catbee/utils/next" alt="NPM Next Version" />
   <img src="https://img.shields.io/npm/dt/@catbee/utils" alt="NPM Downloads" />
   <img src="https://img.shields.io/npm/types/@catbee/utils" alt="TypeScript Types" />
   <img src="https://img.shields.io/librariesio/release/npm/@catbee%2Futils" alt="Dependencies" />
   <img src="https://img.shields.io/maintenance/yes/2025" alt="Maintenance" />
   <img src="https://snyk.io/test/github/<owner>/<repo>/badge.svg" alt="Snyk Vulnerabilities" />
-  <!-- <img src="https://sonarcloud.io/api/project_badges/measure?project=catbee-technologies_catbee-utils&metric=alert_status&token=93da835f2d48d37b41fa628cc7fc764c873bd700" alt="Quality Gate Status" /> -->
+  <img src="https://sonarcloud.io/api/project_badges/measure?project=catbee-technologies_catbee-utils&metric=alert_status&token=93da835f2d48d37b41fa628cc7fc764c873bd700" alt="Quality Gate Status" />
   <img src="https://sonarcloud.io/api/project_badges/measure?project=catbee-technologies_catbee-utils&metric=ncloc&token=93da835f2d48d37b41fa628cc7fc764c873bd700" alt="Lines of Code" />
   <img src="https://sonarcloud.io/api/project_badges/measure?project=catbee-technologies_catbee-utils&metric=security_rating&token=93da835f2d48d37b41fa628cc7fc764c873bd700" alt="Security Rating" />
   <img src="https://sonarcloud.io/api/project_badges/measure?project=catbee-technologies_catbee-utils&metric=sqale_rating&token=93da835f2d48d37b41fa628cc7fc764c873bd700" alt="Maintainability Rating" />

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -15,12 +15,13 @@ A modular, production-grade utility library for Node.js and TypeScript, built fo
   <img src="https://img.shields.io/node/v/@catbee/utils" alt="Node Version" />
   <img src="https://img.shields.io/npm/v/@catbee/utils" alt="NPM Version" />
   <img src="https://img.shields.io/npm/v/@catbee/utils/rc" alt="NPM RC Version" />
+  <img src="https://img.shields.io/npm/v/@catbee/utils/next" alt="NPM Next Version" />
   <img src="https://img.shields.io/npm/dt/@catbee/utils" alt="NPM Downloads" />
   <img src="https://img.shields.io/npm/types/@catbee/utils" alt="TypeScript Types" />
   <img src="https://img.shields.io/librariesio/release/npm/@catbee%2Futils" alt="Dependencies" />
   <img src="https://img.shields.io/maintenance/yes/2025" alt="Maintenance" />
   <img src="https://snyk.io/test/github/<owner>/<repo>/badge.svg" alt="Snyk Vulnerabilities" />
-  <!-- <img src="https://sonarcloud.io/api/project_badges/measure?project=catbee-technologies_catbee-utils&metric=alert_status&token=93da835f2d48d37b41fa628cc7fc764c873bd700" alt="Quality Gate Status" /> -->
+  <img src="https://sonarcloud.io/api/project_badges/measure?project=catbee-technologies_catbee-utils&metric=alert_status&token=93da835f2d48d37b41fa628cc7fc764c873bd700" alt="Quality Gate Status" />
   <img src="https://sonarcloud.io/api/project_badges/measure?project=catbee-technologies_catbee-utils&metric=ncloc&token=93da835f2d48d37b41fa628cc7fc764c873bd700" alt="Lines of Code" />
   <img src="https://sonarcloud.io/api/project_badges/measure?project=catbee-technologies_catbee-utils&metric=security_rating&token=93da835f2d48d37b41fa628cc7fc764c873bd700" alt="Security Rating" />
   <img src="https://sonarcloud.io/api/project_badges/measure?project=catbee-technologies_catbee-utils&metric=sqale_rating&token=93da835f2d48d37b41fa628cc7fc764c873bd700" alt="Maintainability Rating" />

--- a/docs/docs/utils/decorators.md
+++ b/docs/docs/utils/decorators.md
@@ -16,25 +16,27 @@ These utilities provide a declarative way to define Express routes, middleware, 
 - [**`@Head(path: string): MethodDecorator`**](#head) - Define a route for the HEAD HTTP method.
 - [**`@Trace(path: string): MethodDecorator`**](#trace) - Define a route for the TRACE HTTP method.
 - [**`@Connect(path: string): MethodDecorator`**](#connect) - Define a route for the CONNECT HTTP method.
-- [**`@Use(...middlewares: RequestHandler[]): MethodDecorator`**](#use) - Apply Express middleware(s) to a route.
-- [**`@Query(key?: string): ParameterDecorator`**](#query) - Extract query parameters from the request.
-- [**`@Param(key?: string): ParameterDecorator`**](#param) - Extract route parameters from the request.
+- [**`@Use(...middlewares: RequestHandler[]): MethodDecorator & ClassDecorator`**](#use) - Apply Express middleware(s) to a route or controller.
+- [**`@Query(key?: string, options?: ParamOptions): ParameterDecorator`**](#query) - Extract query parameters from the request.
+- [**`@Param(key?: string, options?: ParamOptions): ParameterDecorator`**](#param) - Extract route parameters from the request.
 - [**`@Body(key?: string): ParameterDecorator`**](#body) - Extract body or body property from the request.
 - [**`@Req(): ParameterDecorator`**](#req) - Extract the request object.
 - [**`@Res(): ParameterDecorator`**](#res) - Extract the response object.
+- [**`@ReqHeader(key?: string): ParameterDecorator`**](#reqheader) - Extract request headers.
+- [**`@ReqLogger(): ParameterDecorator`**](#reqlogger) - Inject a logger instance.
 - [**`@HttpCode(status: number): MethodDecorator`**](#httpcode) - Set a custom HTTP status code for the response.
-- [**`@Header(name: string, value: string): MethodDecorator`**](#header) - Add a custom HTTP header to the response.
-- [**`@Headers(headers: Record<string, string> | string, value?: string): MethodDecorator`**](#headers) - Add multiple custom HTTP headers to the response.
-- [**`@Before(fn: Function): MethodDecorator`**](#before) - Run a function before the route handler.
-- [**`@After(fn: Function): MethodDecorator`**](#after) - Run a function after the route handler.
+- [**`@Header(name: string, value: string): MethodDecorator & ClassDecorator`**](#header) - Add a custom HTTP header to the response.
+- [**`@Headers(headers: Record<string, string> | string, value?: string): MethodDecorator & ClassDecorator`**](#headers) - Add multiple custom HTTP headers to the response.
+- [**`@Before(fn: Function): MethodDecorator & ClassDecorator`**](#before) - Run a function before the route handler.
+- [**`@After(fn: Function): MethodDecorator & ClassDecorator`**](#after) - Run a function after the route handler.
 - [**`@Redirect(url?: string, statusCode?: number): MethodDecorator`**](#redirect) - Redirect to another URL.
-- [**`@Roles(...roles: string[]): MethodDecorator`**](#roles) - Require specific roles for accessing a route.
-- [**`@Cache(ttlSeconds: number): MethodDecorator`**](#cache) - Add caching to route responses.
-- [**`@RateLimit(options: RateLimitOptions): MethodDecorator`**](#ratelimit) - Apply rate limiting to routes.
-- [**`@ContentType(type: string): MethodDecorator`**](#contenttype) - Set the content type for responses.
-- [**`@Version(version: string, options?: VersionOptions): MethodDecorator`**](#version) - Add API versioning to routes.
-- [**`@Timeout(ms: number): MethodDecorator`**](#timeout) - Set execution timeout for routes.
-- [**`@Log(options?: LogOptions): MethodDecorator`**](#log) - Add comprehensive logging to routes.
+- [**`@Roles(...roles: string[]): MethodDecorator & ClassDecorator`**](#roles) - Require specific roles for accessing a route.
+- [**`@Cache(ttlSeconds: number): MethodDecorator & ClassDecorator`**](#cache) - Add caching to route responses.
+- [**`@RateLimit(options: RateLimitOptions): MethodDecorator & ClassDecorator`**](#ratelimit) - Apply rate limiting to routes.
+- [**`@ContentType(type: string): MethodDecorator & ClassDecorator`**](#contenttype) - Set the content type for responses.
+- [**`@Version(version: string, options?: VersionOptions): MethodDecorator & ClassDecorator`**](#version) - Add API versioning to routes.
+- [**`@Timeout(ms: number): MethodDecorator & ClassDecorator`**](#timeout) - Set execution timeout for routes.
+- [**`@Log(options?: LogOptions): MethodDecorator & ClassDecorator`**](#log) - Add comprehensive logging to routes.
 - [**`@Injectable(): ClassDecorator`**](#injectable) - Mark a class as injectable for DI.
 - [**`@Inject(targetClass: Constructor): PropertyDecorator`**](#inject) - Inject a dependency into a class property.
 
@@ -74,8 +76,25 @@ interface RouteDefinition {
 // Parameter decoration definition for method parameters
 interface ParamDefinition {
   index: number;
-  type: 'query' | 'param' | 'body' | 'req' | 'res';
+  type: 'query' | 'param' | 'body' | 'req' | 'res' | 'logger' | 'reqHeader';
   key?: string;
+  options?: ParamOptions;
+}
+
+// Parameter options for advanced extraction
+interface ParamOptions<T = any> {
+  type: 'string' | 'number' | 'boolean';
+  dataType?: 'single' | 'array' | 'object';
+  delimiter?: string;
+  default?: T;
+  required?: boolean;
+  throwError?: boolean;
+  min?: number;
+  max?: number;
+  pattern?: RegExp;
+  patternName?: string;
+  validate?: (value: any) => boolean;
+  transform?: (value: any) => any;
 }
 
 // Rate limiting options interface
@@ -402,43 +421,56 @@ connectRoute() {
 ---
 
 ### `@Use()`
-Applies Express middleware(s) to a route.
+Applies Express middleware(s) to a route or entire controller.
 
 **Method Signature:**
 ```ts
-@Use(...middlewares: RequestHandler[]): MethodDecorator
+@Use(...middlewares: RequestHandler[]): MethodDecorator & ClassDecorator
 ```
 
 **Parameters:**
 - `...middlewares`: One or more Express middleware functions.
 
 **Returns:** 
-- A method decorator.
+- A method decorator or class decorator.
 
 **Examples:**
 ```ts
 import { Use, Get, Req } from '@catbee/utils';
 import { authMiddleware, loggingMiddleware } from './middlewares';
 
-@Use(authMiddleware, loggingMiddleware)
+// Method-level middleware
 @Get('/protected')
+@Use(authMiddleware, loggingMiddleware)
 getProtected(@Req() req: any) {
   return { user: req.user };
+}
+
+// Controller-level middleware
+@Controller('/api')
+@Use(authMiddleware, loggingMiddleware)
+class ApiController {
+  // All routes in this controller will use the middleware
+  @Get('/me')
+  getProfile() {
+    return { profile: 'data' };
+  }
 }
 ```
 
 ---
 
 ### `@Query()`
-Extracts query parameters from the request.
+Extracts query parameters from the request with optional type conversion and validation.
 
 **Method Signature:**
 ```ts
-@Query(key?: string): ParameterDecorator
+@Query(key?: string, options?: ParamOptions): ParameterDecorator
 ```
 
 **Parameters:**
 - `key`: The query parameter key.
+- `options`: Optional parameter options for type conversion, validation, and more.
 
 **Returns:** 
 - A parameter decorator.
@@ -448,23 +480,60 @@ Extracts query parameters from the request.
 import { Get, Query } from '@catbee/utils';
 
 @Get('/search')
-search(@Query('term') term: string) {
-  return { results: [], term };
+search(
+  // Simple usage: Get query parameter as string
+  @Query('term') term: string,
+  
+  // With type conversion: Get page as number with default value
+  @Query('page', { type: 'number', default: 1 }) page: number,
+  
+  // Array conversion: Convert comma-separated list to array of numbers
+  @Query('ids', { type: 'number', dataType: 'array' }) ids: number[],
+  
+  // Required parameter with validation
+  @Query('minPrice', { 
+    type: 'number',
+    required: true, 
+    validate: (price) => price > 0 
+  }) minPrice: number,
+  
+  // With custom transformation
+  @Query('sort', { 
+    transform: (val) => val.toUpperCase(),
+    validate: (val) => ['ASC', 'DESC'].includes(val)
+  }) sort: string
+) {
+  return { results: [], term, page, ids, minPrice, sort };
+}
+
+@Get('/advanced')
+advanced(
+  // Custom delimiter for arrays
+  @Query('tags', { dataType: 'array', delimiter: '|' }) tags: string[],
+  
+  // Parse JSON from query parameter
+  @Query('filter', { dataType: 'object' }) filter: any,
+  
+  // Get all query parameters
+  @Query() allParams: any
+) {
+  return { tags, filter, allParams };
 }
 ```
 
 ---
 
 ### `@Param()`
-Extracts route parameters from the request.
+Extracts route parameters from the request with optional type conversion and validation.
 
 **Method Signature:**
 ```ts
-@Param(key?: string): ParameterDecorator
+@Param(key?: string, options?: ParamOptions): ParameterDecorator
 ```
 
 **Parameters:**
 - `key`: The route parameter key.
+- `options`: Optional parameter options for type conversion, validation, and more.
 
 **Returns:** 
 - A parameter decorator.
@@ -474,8 +543,31 @@ Extracts route parameters from the request.
 import { Get, Param } from '@catbee/utils';
 
 @Get('/users/:id')
-getUser(@Param('id') userId: string) {
-  return { userId };
+getUser(
+  // Basic usage
+  @Param('id') id: string,
+  
+  // Convert to number with validation
+  @Param('id', { 
+    type: 'number', 
+    validate: (id) => id > 0 
+  }) numericId: number
+) {
+  return { userId: id, numericId };
+}
+
+@Get('/items/:category/:itemId')
+getItem(
+  // Required parameter
+  @Param('itemId', { required: true }) itemId: string,
+  
+  // Convert to boolean
+  @Param('inStock', { type: 'boolean' }) inStock: boolean,
+  
+  // Get all route parameters
+  @Param() allParams: any
+) {
+  return { itemId, inStock, allParams };
 }
 ```
 
@@ -558,6 +650,75 @@ custom(@Res() res: any) {
 
 ---
 
+### `@ReqHeader()`
+Extracts headers from the request.
+
+**Method Signature:**
+```ts
+@ReqHeader(key?: string): ParameterDecorator
+```
+
+**Parameters:**
+- `key`: The header name to extract. Case-insensitive.
+
+**Returns:** 
+- A parameter decorator.
+
+**Examples:**
+```ts
+import { Get, ReqHeader } from '@catbee/utils';
+
+@Get('/data')
+getData(
+  // Extract specific header
+  @ReqHeader('authorization') auth: string,
+  
+  // Extract content type
+  @ReqHeader('content-type') contentType: string,
+  
+  // Get all headers
+  @ReqHeader() allHeaders: any
+) {
+  return { 
+    authorized: auth ? 'yes' : 'no', 
+    contentType,
+    headers: allHeaders 
+  };
+}
+```
+
+---
+
+### `@ReqLogger()`
+Injects a logger instance.
+
+**Method Signature:**
+```ts
+@ReqLogger(): ParameterDecorator
+```
+
+**Returns:** 
+- A parameter decorator.
+
+**Examples:**
+```ts
+import { Get, ReqLogger } from '@catbee/utils';
+
+@Get('/log')
+logData(@ReqLogger() logger: any, @Param('id') id: string) {
+  logger.info({ id }, 'Accessing data endpoint');
+  return { logged: true };
+}
+
+@Post('/items')
+createItem(@Body() data: any, @ReqLogger() logger: any) {
+  logger.info({ data }, 'Creating new item');
+  return { created: true };
+}
+```
+
+---
+
 ### `@HttpCode()`
 Sets a custom HTTP status code for the response.
 
@@ -590,7 +751,7 @@ Adds a custom HTTP header to the response.
 
 **Method Signature:**
 ```ts
-@Header(name: string, value: string): MethodDecorator
+@Header(name: string, value: string): MethodDecorator & ClassDecorator
 ```
 
 **Parameters:**
@@ -598,7 +759,7 @@ Adds a custom HTTP header to the response.
 - `value`: The value of the HTTP header.
 
 **Returns:** 
-- A method decorator.
+- A method decorator or class decorator.
 
 **Examples:**
 ```ts
@@ -609,6 +770,12 @@ import { Get, Header } from '@catbee/utils';
 getData() {
   return { data: '...' };
 }
+
+@Controller('/api/v1')
+@Header('API-Version', 'v1')
+class ApiV1Controller {
+  // All routes in this controller will include the header
+}
 ```
 
 ---
@@ -618,7 +785,7 @@ Adds multiple custom HTTP headers to the response.
 
 **Method Signature:**
 ```ts
-@Headers(headers: Record<string, string> | string, value?: string): MethodDecorator
+@Headers(headers: Record<string, string> | string, value?: string): MethodDecorator & ClassDecorator
 ```
 
 **Parameters:**
@@ -626,7 +793,7 @@ Adds multiple custom HTTP headers to the response.
 - `value`: Header value (required when first parameter is a string)
 
 **Returns:** 
-- A method decorator.
+- A method decorator or class decorator.
 
 **Examples:**
 ```ts
@@ -649,6 +816,16 @@ getData() {
 getSecureData() {
   return { data: 'secure content' };
 }
+
+// Controller-level headers
+@Controller('/api/public')
+@Headers({
+  'Access-Control-Allow-Origin': '*',
+  'X-API-Type': 'public'
+})
+class PublicApiController {
+  // All routes in this controller will include these headers
+}
 ```
 
 ---
@@ -658,23 +835,38 @@ Runs a function before the route handler.
 
 **Method Signature:**
 ```ts
-@Before(fn: (req: Request, res: Response) => void): MethodDecorator
+@Before(fn: (req: Request, res: Response) => void): MethodDecorator & ClassDecorator
 ```
 
 **Parameters:**
 - `fn`: A function that takes the request and response objects.
 
 **Returns:** 
-- A method decorator.
+- A method decorator or class decorator.
 
 **Examples:**
 ```ts
 import { Before, Get, Param } from '@catbee/utils';
 
+// Method-level hook
 @Get('/users/:id')
 @Before((req, res) => console.log(`Accessing user ${req.params.id}`))
 getUser(@Param('id') id: string) {
   return { id };
+}
+
+// Controller-level hook
+@Controller('/api')
+@Before((req, res) => {
+  console.log(`API access: ${req.method} ${req.path}`);
+  req.startTime = Date.now();
+})
+class ApiController {
+  // This hook runs before all routes in the controller
+  @Get('/data')
+  getData() {
+    return { data: 'example' };
+  }
 }
 ```
 
@@ -685,23 +877,38 @@ Runs a function after the route handler, can access the result.
 
 **Method Signature:**
 ```ts
-@After(fn: (req: Request, res: Response, result: any) => void): MethodDecorator
+@After(fn: (req: Request, res: Response, result: any) => void): MethodDecorator & ClassDecorator
 ```
 
 **Parameters:**
 - `fn`: A function that takes the request, response, and result objects.
 
 **Returns:** 
-- A method decorator.
+- A method decorator or class decorator.
 
 **Examples:**
 ```ts
 import { After, Get, Param } from '@catbee/utils';
 
+// Method-level hook
 @Get('/users/:id')
 @After((req, res, result) => console.log(`User data sent: ${JSON.stringify(result)}`))
 getUser(@Param('id') id: string) {
   return { id, name: 'Example' };
+}
+
+// Controller-level hook
+@Controller('/api')
+@After((req, res, result) => {
+  const duration = Date.now() - req.startTime;
+  console.log(`Request processed in ${duration}ms`);
+})
+class ApiController {
+  // This hook runs after all routes in the controller
+  @Get('/data')
+  getData() {
+    return { data: 'example' };
+  }
 }
 ```
 
@@ -745,23 +952,42 @@ Requires specific roles for accessing a route.
 
 **Method Signature:**
 ```ts
-@Roles(...roles: string[]): MethodDecorator
+@Roles(...roles: string[]): MethodDecorator & ClassDecorator
 ```
 
 **Parameters:**
 - `...roles`: The roles required to access the route.
 
 **Returns:** 
-- A method decorator.
+- A method decorator or class decorator.
 
 **Examples:**
 ```ts
-import { Roles, Get } from '@catbee/utils';
+import { Roles, Get, Controller } from '@catbee/utils';
 
+// Method-level roles
 @Get('/admin/settings')
 @Roles('admin', 'superuser')
 getSettings() {
   return { settings: ['a', 'b'] };
+}
+
+// Controller-level roles
+@Controller('/admin')
+@Roles('admin')
+class AdminController {
+  // All routes in this controller require the 'admin' role
+  @Get('/users')
+  getUsers() {
+    return { users: [] };
+  }
+  
+  // Override controller-level roles for specific methods
+  @Get('/metrics')
+  @Roles('admin', 'analyst')
+  getMetrics() {
+    return { metrics: {} };
+  }
 }
 ```
 
@@ -772,32 +998,45 @@ Adds caching headers to route responses for client-side caching.
 
 **Method Signature:**
 ```ts
-@Cache(ttlSeconds: number): MethodDecorator
+@Cache(ttlSeconds: number): MethodDecorator & ClassDecorator
 ```
 
 **Parameters:**
 - `ttlSeconds`: Time to live in seconds for the cache
 
 **Returns:** 
-- A method decorator.
+- A method decorator or class decorator.
 
 **Headers Set:**
 - `Cache-Control: public, max-age={ttlSeconds}`
 
 **Examples:**
 ```ts
-import { Get, Cache } from '@catbee/utils';
+import { Get, Cache, Controller } from '@catbee/utils';
 
+// Method-level cache
 @Get('/static-data')
 @Cache(300) // Cache for 5 minutes
 getStaticData() {
   return { data: 'This data changes infrequently' };
 }
 
-@Get('/user-profile/:id')
-@Cache(60) // Cache for 1 minute
-getUserProfile(@Param('id') id: string) {
-  return this.userService.getProfile(id);
+// Controller-level cache
+@Controller('/api/public')
+@Cache(60) // Default 1 minute cache for all routes
+class PublicApiController {
+  // Uses controller-level cache (60 seconds)
+  @Get('/countries')
+  getCountries() {
+    return { countries: [] };
+  }
+  
+  // Override with method-level cache
+  @Get('/exchange-rates')
+  @Cache(600) // Override with 10 minutes for this specific route
+  getExchangeRates() {
+    return { rates: {} };
+  }
 }
 ```
 
@@ -808,7 +1047,7 @@ Applies rate limiting to routes using express-rate-limit.
 
 **Method Signature:**
 ```ts
-@RateLimit(options: RateLimitOptions): MethodDecorator
+@RateLimit(options: RateLimitOptions): MethodDecorator & ClassDecorator
 ```
 
 **Parameters:**
@@ -826,29 +1065,37 @@ Applies rate limiting to routes using express-rate-limit.
 ```
 
 **Returns:** 
-- A method decorator.
+- A method decorator or class decorator.
 
 **Note:** Requires `express-rate-limit` package to be installed.
 
 **Examples:**
 ```ts
-import { Post, RateLimit, Body } from '@catbee/utils';
+import { Post, RateLimit, Body, Controller } from '@catbee/utils';
 
+// Method-level rate limit
 @Post('/login')
 @RateLimit({ max: 5, windowMs: 60000 }) // 5 requests per minute
 login(@Body() credentials: any) {
   return this.authService.login(credentials);
 }
 
-@Post('/api/data')
-@RateLimit({ 
-  max: 100, 
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  standardHeaders: true,
-  legacyHeaders: false 
-})
-createData(@Body() data: any) {
-  return this.dataService.create(data);
+// Controller-level rate limit
+@Controller('/api')
+@RateLimit({ max: 100, windowMs: 60 * 1000 }) // 100 requests per minute
+class ApiController {
+  // All routes use controller-level rate limiting
+  @Get('/data')
+  getData() {
+    return { data: [] };
+  }
+  
+  // Stricter rate limit for sensitive operations
+  @Post('/payments')
+  @RateLimit({ max: 10, windowMs: 60 * 1000 }) // 10 requests per minute
+  processPayment(@Body() payment: any) {
+    return { status: 'processing' };
+  }
 }
 ```
 
@@ -859,38 +1106,45 @@ Sets the content type header for the response.
 
 **Method Signature:**
 ```ts
-@ContentType(type: string): MethodDecorator
+@ContentType(type: string): MethodDecorator & ClassDecorator
 ```
 
 **Parameters:**
 - `type`: MIME type for the response
 
 **Returns:** 
-- A method decorator.
+- A method decorator or class decorator.
 
 **Headers Set:**
 - `Content-Type: {type}`
 
 **Examples:**
 ```ts
-import { Get, ContentType } from '@catbee/utils';
+import { Get, ContentType, Controller } from '@catbee/utils';
 
+// Method-level content type
 @Get('/download/pdf')
 @ContentType('application/pdf')
 downloadPdf() {
   return this.fileService.generatePdf();
 }
 
-@Get('/api/xml')
+// Controller-level content type
+@Controller('/api/xml')
 @ContentType('application/xml')
-getXmlData() {
-  return this.dataService.toXml();
-}
-
-@Get('/feed.rss')
-@ContentType('application/rss+xml')
-getRssFeed() {
-  return this.feedService.generateRss();
+class XmlApiController {
+  // All routes return XML content
+  @Get('/data')
+  getData() {
+    return '<data><item>1</item></data>';
+  }
+  
+  // Override with method-level content type
+  @Get('/json-data')
+  @ContentType('application/json')
+  getJsonData() {
+    return { data: [1, 2, 3] };
+  }
 }
 ```
 
@@ -901,7 +1155,7 @@ Adds API versioning to routes with configurable prefix and header options.
 
 **Method Signature:**
 ```ts
-@Version(version: string, options?: VersionOptions): MethodDecorator
+@Version(version: string, options?: VersionOptions): MethodDecorator & ClassDecorator
 ```
 
 **Parameters:**
@@ -920,30 +1174,35 @@ Adds API versioning to routes with configurable prefix and header options.
 ```
 
 **Returns:** 
-- A method decorator.
+- A method decorator or class decorator.
 
 **Examples:**
 ```ts
-import { Get, Version } from '@catbee/utils';
+import { Get, Version, Controller } from '@catbee/utils';
 
+// Method-level versioning
 @Get('/users')
 @Version('v2') // Route becomes /v2/users, adds X-API-Version: v2 header
 getUsersV2() {
   return this.userService.findAllV2();
 }
 
-@Get('/data')
-@Version('v3', { addPrefix: false, addHeader: true, headerName: 'API-Version' })
-getDataV3() {
-  // Route stays /data, adds API-Version: v3 header
-  return this.dataService.getV3();
-}
-
-@Get('/legacy')
-@Version('v1', { addPrefix: true, addHeader: false })
-getLegacyData() {
-  // Route becomes /v1/legacy, no version header
-  return this.legacyService.getData();
+// Controller-level versioning
+@Controller('/api')
+@Version('v3')
+class ApiV3Controller {
+  // All routes are prefixed with /v3 and include X-API-Version: v3 header
+  @Get('/users')
+  getUsers() {
+    return { users: [] };
+  }
+  
+  // Method-level versioning overrides controller-level
+  @Get('/experimental')
+  @Version('v4')
+  getExperimental() {
+    return { experimental: true };
+  }
 }
 ```
 
@@ -954,14 +1213,14 @@ Sets execution timeout for route handlers to prevent long-running requests.
 
 **Method Signature:**
 ```ts
-@Timeout(ms: number): MethodDecorator
+@Timeout(ms: number): MethodDecorator & ClassDecorator
 ```
 
 **Parameters:**
 - `ms`: Timeout duration in milliseconds
 
 **Returns:** 
-- A method decorator.
+- A method decorator or class decorator.
 
 **Behavior:**
 - If the route handler takes longer than the specified time, a 408 Request Timeout response is sent
@@ -969,24 +1228,31 @@ Sets execution timeout for route handlers to prevent long-running requests.
 
 **Examples:**
 ```ts
-import { Get, Timeout } from '@catbee/utils';
+import { Get, Timeout, Controller } from '@catbee/utils';
 
+// Method-level timeout
 @Get('/slow-operation')
 @Timeout(30000) // 30 second timeout
 async slowOperation() {
   return await this.heavyService.processLargeDataset();
 }
 
-@Post('/upload')
-@Timeout(60000) // 1 minute timeout for file uploads
-async uploadFile(@Body() fileData: any) {
-  return await this.fileService.processUpload(fileData);
-}
-
-@Get('/report')
-@Timeout(120000) // 2 minute timeout for report generation
-async generateReport(@Query('type') type: string) {
-  return await this.reportService.generate(type);
+// Controller-level timeout
+@Controller('/api/reports')
+@Timeout(60000) // 1 minute default timeout
+class ReportsController {
+  // Uses controller-level timeout (60 seconds)
+  @Get('/daily')
+  async getDailyReport() {
+    return await this.reportService.generateDaily();
+  }
+  
+  // Override with method-level timeout
+  @Get('/annual')
+  @Timeout(120000) // 2 minutes for this specific operation
+  async getAnnualReport() {
+    return await this.reportService.generateAnnual();
+  }
 }
 ```
 
@@ -997,7 +1263,7 @@ Adds comprehensive logging to routes for monitoring and debugging.
 
 **Method Signature:**
 ```ts
-@Log(options?: LogOptions): MethodDecorator
+@Log(options?: LogOptions): MethodDecorator & ClassDecorator
 ```
 
 **Parameters:**
@@ -1019,7 +1285,7 @@ Adds comprehensive logging to routes for monitoring and debugging.
 ```
 
 **Returns:** 
-- A method decorator.
+- A method decorator or class decorator.
 
 **Log Information:**
 - Entry logs: method, URL, user agent, timestamp
@@ -1028,37 +1294,37 @@ Adds comprehensive logging to routes for monitoring and debugging.
 
 **Examples:**
 ```ts
-import { Post, Log, Body, Param } from '@catbee/utils';
+import { Post, Log, Body, Param, Controller } from '@catbee/utils';
 
-// Basic logging (entry and exit only)
+// Method-level logging
 @Post('/users')
 @Log()
 createUser(@Body() userData: any) {
   return this.userService.create(userData);
 }
 
-// Comprehensive logging
-@Post('/orders/:id/process')
-@Log({
-  logEntry: true,
-  logExit: true,
-  logBody: true,
-  logParams: true,
-  logResponse: false // Don't log response for security
-})
-processOrder(@Param('id') id: string, @Body() orderData: any) {
-  return this.orderService.process(id, orderData);
-}
-
-// Minimal logging (exit only with response)
-@Get('/public/stats')
-@Log({
-  logEntry: false,
-  logExit: true,
-  logResponse: true
-})
-getPublicStats() {
-  return this.statsService.getPublic();
+// Controller-level logging
+@Controller('/api')
+@Log({ logEntry: true, logExit: true, logParams: true })
+class ApiController {
+  // Uses controller-level logging configuration
+  @Get('/users/:id')
+  getUser(@Param('id') id: string) {
+    return { id, name: 'Test' };
+  }
+  
+  // Override with method-level logging
+  @Post('/orders')
+  @Log({
+    logEntry: true,
+    logExit: true,
+    logBody: true,
+    logParams: true,
+    logResponse: false // Don't log response for security
+  })
+  createOrder(@Body() orderData: any) {
+    return this.orderService.create(orderData);
+  }
 }
 ```
 
@@ -1134,32 +1400,70 @@ class UserController {
 
 ---
 
+
+### `inject()`
+A function to manually inject a dependency outside of class decorators.
+
+**Method Signature:**
+```ts
+function inject<T>(targetClass: Constructor<T>): T
+```
+**Parameters:**
+- `targetClass`: The class to inject.
+
+**Examples:**
+```ts
+import { inject, Controller } from '@catbee/utils';
+
+@Injectable()
+class UserService {
+  getUser() { /* ... */ }
+}
+
+@Controller('/api/users')
+class UserController {
+  userService = inject(UserService);
+}
+```
+
+---
+
 ## Controller-Level Decorator Inheritance
 
 Many decorators can be applied at the controller level and will be inherited by all methods in that controller, unless overridden at the method level.
 
 **Inheritable Decorators:**
 - `@Headers()`
+- `@Before()`
+- `@After()`
 - `@Cache()`
 - `@RateLimit()`
 - `@Version()`
 - `@Timeout()`
 - `@Log()`
 - `@Roles()`
+- `@ContentType()`
+- `@Use()`
 
 **Examples:**
 ```ts
-import { Controller, Get, Post, Cache, Headers, Roles, Version } from '@catbee/utils';
+import { Controller, Get, Post, Cache, Headers, Roles, Version, Use, ContentType, Before, After } from '@catbee/utils';
+import { authMiddleware, loggingMiddleware } from './middleware';
 
 @Controller('/api/admin')
 @Cache(300) // All routes cached for 5 minutes by default
 @Headers({ 'X-Admin-API': 'true' }) // All routes get this header
 @Roles('admin') // All routes require admin role
 @Version('v2') // All routes are v2
+@Use(authMiddleware, loggingMiddleware) // All routes use these middlewares
+@ContentType('application/json') // All routes return JSON
+@Before((req, res) => console.log(`Admin API request: ${req.method} ${req.path}`))
+@After((req, res, result) => console.log(`Admin API response sent in ${Date.now() - req.startTime}ms`))
 class AdminController {
   
   @Get('/users')
-  // Inherits: @Cache(300), @Headers({'X-Admin-API': 'true'}), @Roles('admin'), @Version('v2')
+  // Inherits: @Cache(300), @Headers({'X-Admin-API': 'true'}), @Roles('admin'), 
+  // @Version('v2'), @Use(...), @ContentType('application/json'), @Before(...), @After(...)
   getUsers() {
     return this.userService.findAll();
   }
@@ -1173,6 +1477,7 @@ class AdminController {
   
   @Post('/settings')
   @Roles('superadmin') // Overrides controller-level roles
+  @ContentType('application/xml') // Overrides controller-level content type
   updateSettings(@Body() settings: any) {
     return this.settingsService.update(settings);
   }

--- a/docs/docs/utils/logger.md
+++ b/docs/docs/utils/logger.md
@@ -4,7 +4,7 @@ Structured logging with Pino. This module provides a robust logging system with 
 
 ## API Summary
 
-- [**`getLogger(): Logger`**](#getlogger) - Retrieves the current logger instance from the request context or falls back to the global logger.
+- [**`getLogger(newInstance?: boolean): Logger`**](#getlogger) - Retrieves the current logger instance from the request context or falls back to the global logger.
 - [**`createChildLogger(bindings: Record<string, any>, parentLogger?: Logger): Logger`**](#createchildlogger) - Creates a child logger with additional context that will be included in all log entries.
 - [**`createRequestLogger(requestId: string, additionalContext?: Record<string, any>): Logger`**](#createrequestlogger) - Creates a request-scoped logger with request ID and stores it in the async context.
 - [**`logError(error: Error | unknown, message?: string, context?: Record<string, any>): void`**](#logerror) - Utility to safely log errors with proper stack trace extraction
@@ -61,11 +61,14 @@ Retrieves the current logger instance from the request context or falls back to 
 
 **Method Signature:**
 ```ts
-function getLogger(): Logger
+function getLogger(newInstance?: boolean): Logger
 ```
 
+**Parameters:**
+- `newInstance` (optional): If `true`, returns a fresh logger instance without any request context or global configuration. Default is `false`.
+
 **Returns:**
-- The current `Logger` instance.
+- The current `Logger` instance, or a new instance if `newInstance` is `true`.
 
 **Example:**
 ```ts
@@ -75,6 +78,10 @@ import { getLogger } from "@catbee/utils";
 const logger = getLogger();
 logger.info("App started");
 logger.debug({ user: "john" }, "User logged in");
+
+// Create a completely fresh logger instance without request context
+const freshLogger = getLogger(true);
+freshLogger.info("Logging outside of request context");
 ```
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@catbee/utils",
-  "version": "0.0.8-rc.4",
+  "version": "0.0.8-next.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@catbee/utils",
-      "version": "0.0.8-rc.4",
+      "version": "0.0.8-next.0",
       "license": "MIT",
       "devDependencies": {
         "@swc/core": "^1.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catbee/utils",
-  "version": "0.0.8-rc.4",
+  "version": "0.0.8-next.0",
   "description": "A modular, production-grade utility toolkit for Node.js and TypeScript, designed for robust, scalable applications (including Express-based services). All utilities are tree-shakable and can be imported independently.",
   "main": "build/index.cjs",
   "module": "build/index.mjs",

--- a/src/utils/decorators.utils.ts
+++ b/src/utils/decorators.utils.ts
@@ -29,6 +29,7 @@ import { createFinalErrorResponse } from './response.utils';
 import { HttpStatusCodes } from './http-status-codes';
 import { rateLimit } from 'express-rate-limit';
 import { TTLCache } from './cache.utils';
+import { BadRequestException } from './exception.utils';
 
 // Metadata keys
 const ROUTES_KEY = Symbol('routes');
@@ -71,9 +72,11 @@ interface ParamDefinition {
   /** Parameter position in method signature */
   index: number;
   /** Type of parameter (query, body, etc.) */
-  type: 'query' | 'param' | 'body' | 'req' | 'res';
+  type: 'query' | 'param' | 'body' | 'req' | 'res' | 'logger' | 'reqHeader';
   /** Optional key for extracting specific property */
   key?: string;
+  /** Optional ParamOptions for advanced extraction */
+  options?: ParamOptions;
 }
 
 type CachedRateLimiter = {
@@ -153,15 +156,37 @@ const rateLimiterCache = new RateLimiterCache();
 // di.container.ts
 type Constructor<T = any> = new (...args: any[]) => T;
 
+// Add this interface to track property injections
+interface PropertyInjection {
+  targetClass: Constructor;
+  propertyKey: string | symbol;
+}
+
 export class DIContainer {
   private instances = new Map<Constructor, any>();
   private constructing = new Map<Constructor, any>();
+  private propertyInjections = new Map<Constructor, PropertyInjection[]>();
 
   register<T>(target: Constructor<T>) {
     // Mark as injectable, but do not instantiate yet
     if (!this.instances.has(target) && !this.constructing.has(target)) {
       // No-op: instantiation is deferred until get()
     }
+  }
+
+  /**
+   * Register a property injection to be resolved when the target class is instantiated
+   */
+  registerPropertyInjection(target: object, propertyKey: string | symbol, injectClass: Constructor) {
+    const targetClass = target.constructor as Constructor;
+    if (!this.propertyInjections.has(targetClass)) {
+      this.propertyInjections.set(targetClass, []);
+    }
+
+    this.propertyInjections.get(targetClass)!.push({
+      targetClass: injectClass,
+      propertyKey
+    });
   }
 
   get<T>(target: Constructor<T>): T {
@@ -184,6 +209,9 @@ export class DIContainer {
     const dependencies = paramTypes.map(dep => this.get(dep));
     const instance = new target(...dependencies);
 
+    // Apply property injections
+    this.applyPropertyInjections(target, instance);
+
     // Copy instance properties to proxy (for circular refs)
     Object.assign(proxy, instance);
 
@@ -197,9 +225,23 @@ export class DIContainer {
     return proxy;
   }
 
+  private applyPropertyInjections(targetClass: Constructor, instance: any) {
+    // Get property injections for this class
+    const injections = this.propertyInjections.get(targetClass) || [];
+
+    for (const injection of injections) {
+      // Get the dependency instance
+      const dependency = this.get(injection.targetClass);
+
+      // Apply the dependency to the instance
+      instance[injection.propertyKey] = dependency;
+    }
+  }
+
   clear() {
     this.instances.clear();
     this.constructing.clear();
+    this.propertyInjections.clear();
   }
 }
 
@@ -234,14 +276,52 @@ export function Injectable(): ClassDecorator {
  */
 export function Inject<T>(targetClass: new (...args: any[]) => T): PropertyDecorator {
   return (target, propertyKey) => {
+    // Register the property injection for resolution during instantiation
+    diContainer.registerPropertyInjection(target, propertyKey, targetClass);
+
+    // Also define a property getter for immediate access if needed
     Object.defineProperty(target, propertyKey, {
+      configurable: true,
       get: function () {
-        return diContainer.get(targetClass);
+        // Try to get existing property value first (might be already set)
+        const value = Object.getOwnPropertyDescriptor(this, propertyKey)?.value;
+        if (value !== undefined) return value;
+
+        // Otherwise get from container
+        const injectedValue = diContainer.get(targetClass);
+
+        // Store the value directly on the instance to avoid repeated lookups
+        Object.defineProperty(this, propertyKey, {
+          value: injectedValue,
+          writable: true,
+          configurable: true
+        });
+
+        return injectedValue;
       },
-      enumerable: true,
-      configurable: true
+      set: function (value) {
+        // Allow overwriting the injected value
+        Object.defineProperty(this, propertyKey, {
+          value,
+          writable: true,
+          configurable: true
+        });
+      }
     });
   };
+}
+
+/**
+ * Inject function for retrieving instances from the DI container.
+ * @param targetClass - The class to inject
+ *
+ * @returns The instance of the requested class
+ *
+ * @example
+ * const a = inject(TestClass);
+ */
+export function inject<T>(targetClass: new (...args: any[]) => T): T {
+  return diContainer.get(targetClass);
 }
 
 /**
@@ -374,11 +454,11 @@ export function Controller(basePath: string): ClassDecorator {
 }
 
 /**
- * Decorator that applies middleware to a controller method.
+ * Decorator that applies middleware to a controller method or an entire controller.
  * Multiple middlewares can be applied and will execute in order.
  *
  * @param middlewares - Express middleware functions to apply
- * @returns Method decorator
+ * @returns Method decorator or Class decorator
  *
  * @example
  * ```ts
@@ -387,23 +467,79 @@ export function Controller(basePath: string): ClassDecorator {
  * getProtectedResource() {
  *   // This route is protected by auth middleware
  * }
+ *
+ * @Controller('/api')
+ * @Use(commonMiddleware)
+ * class ApiController {
+ *   // All routes in this controller use the middleware
+ * }
  * ```
  */
-export function Use(...middlewares: RequestHandler[]): MethodDecorator {
-  return (target, propertyKey, _descriptor) => {
-    const existing: RequestHandler[] =
-      Reflect.getMetadata(MIDDLEWARE_KEY, target as object, propertyKey as string) || [];
-    Reflect.defineMetadata(MIDDLEWARE_KEY, [...existing, ...middlewares], target as object, propertyKey as string);
+export function Use(...middlewares: RequestHandler[]): MethodDecorator & ClassDecorator {
+  return (target: any, propertyKey?: string | symbol, _descriptor?: PropertyDescriptor) => {
+    if (typeof propertyKey === 'undefined') {
+      // Class decorator
+      const existing: RequestHandler[] = Reflect.getMetadata(MIDDLEWARE_KEY, target as object) || [];
+      Reflect.defineMetadata(MIDDLEWARE_KEY, [...existing, ...middlewares], target as object);
+    } else {
+      // Method decorator
+      const existing: RequestHandler[] = Reflect.getMetadata(MIDDLEWARE_KEY, target as object, propertyKey) || [];
+      Reflect.defineMetadata(MIDDLEWARE_KEY, [...existing, ...middlewares], target as object, propertyKey);
+    }
   };
 }
 
 /**
- * Factory function that creates parameter decorators.
+ * Options for parameter decorators
+ * @template T - Type of the parameter value after transformation
  *
- * @param type - Parameter type to extract from request
- * @param key - Optional fixed key for extraction
- * @returns Parameter decorator function
+ * @property type - Base type of the parameter (default: 'string')'
+ * @property dataType - Data structure type (single, array, object)
+ * @property delimiter - Delimiter for array types
+ * @property default - Default value if parameter is missing
+ * @property required - Whether the parameter is required
+ * @property throwError - Throw error on validation failure
+ * @property validate - Custom validation function
+ * @property transform - Custom transformation function
  */
+export interface ParamOptions<T = any> {
+  /** Base type of the parameter (default: 'string') */
+  type: 'string' | 'number' | 'boolean';
+
+  /** Data structure type (default: 'single') */
+  dataType?: 'single' | 'array' | 'object';
+
+  /** Delimiter for array types (default: ',') */
+  delimiter?: string;
+
+  /** Default value if parameter is missing */
+  default?: T;
+
+  /** Whether the parameter is required (default: false) */
+  required?: boolean;
+
+  /** Throw error on validation failure (default: true) */
+  throwError?: boolean;
+
+  /** Minimum value for number type */
+  min?: number;
+
+  /** Maximum value for number type */
+  max?: number;
+
+  /** Regex pattern the value must match */
+  pattern?: RegExp;
+
+  /** Name of the pattern for error messages */
+  patternName?: string;
+
+  /** Custom validation function */
+  validate?: (value: any) => boolean;
+
+  /** Custom transformation function */
+  transform?: (value: any) => any;
+}
+
 function createParamDecorator(type: ParamDefinition['type'], key?: string) {
   return (paramKey?: string): ParameterDecorator => {
     return (target, propertyKey, parameterIndex) => {
@@ -417,36 +553,71 @@ function createParamDecorator(type: ParamDefinition['type'], key?: string) {
 }
 
 /**
+ * Factory function that creates parameter decorators.
+ *
+ * @param type - Parameter type to extract from request
+ * @param key - Optional fixed key for extraction
+ * @returns Parameter decorator function
+ */
+function createApiUrlParamDecorator(type: ParamDefinition['type'], key?: string) {
+  return (paramKey?: string, options?: ParamOptions): ParameterDecorator => {
+    return (target, propertyKey, parameterIndex) => {
+      const params: ParamDefinition[] = Reflect.getMetadata(PARAMS_KEY, target as object, propertyKey as string) || [];
+      // Ensure parameters are ordered by index
+      let paramOptions: ParamOptions | undefined = undefined;
+      if (typeof options === 'object') {
+        paramOptions = {} as ParamOptions;
+        paramOptions.type = 'string';
+        paramOptions.dataType = 'single';
+        paramOptions.delimiter = ',';
+        paramOptions.required = false;
+        paramOptions.throwError = true;
+        paramOptions = {
+          ...paramOptions,
+          ...options
+        };
+      }
+      params.push({ index: parameterIndex, type, key: paramKey || key, options: paramOptions });
+      params.sort((a, b) => a.index - b.index);
+      Reflect.defineMetadata(PARAMS_KEY, params, target as object, propertyKey as string);
+    };
+  };
+}
+
+/**
  * Decorator that extracts query parameters from request.
  *
  * @param paramKey - Optional key to extract specific query parameter
+ * @param options - Optional ParamOptions
  * @returns Parameter decorator
  *
  * @example
  * ```ts
  * @Get('/search')
- * search(@Query('term') searchTerm: string) {
- *   // searchTerm will contain the value of req.query.term
+ * search(@Query('term') term: string, @Query('page', { type: 'number', default: 1 }) page: number) {
+ *   // term will contain the value of req.query.term
+ *   // page will contain the numeric value of req.query.page or default to 1
  * }
  * ```
  */
-export const Query = createParamDecorator('query');
+export const Query = createApiUrlParamDecorator('query');
 
 /**
  * Decorator that extracts route parameters from request.
  *
  * @param paramKey - Optional key to extract specific route parameter
+ * @param options - Optional ParamOptions
  * @returns Parameter decorator
  *
- * @example
+ *  @example
  * ```ts
  * @Get('/users/:id')
- * getUser(@Param('id') userId: string) {
- *   // userId will contain the value of req.params.id
+ * getUser(@Param('id') id: string) {
+ *   // id will contain the value of req.params.id
  * }
  * ```
  */
-export const Param = createParamDecorator('param');
+export const Param = createApiUrlParamDecorator('param');
 
 /**
  * Decorator that extracts body or body property from request.
@@ -468,6 +639,35 @@ export const Param = createParamDecorator('param');
  * ```
  */
 export const Body = createParamDecorator('body');
+
+/**
+ * Decorator that injects a logger instance.
+ * @returns Parameter decorator
+ *
+ * @example
+ * ```ts
+ * @Get('/log')
+ * log(@ReqLogger() logger: Logger) {
+ *   logger.info('Logging request...');
+ * }
+ * ```
+ */
+export const ReqLogger = createParamDecorator('logger');
+
+/**
+ * Decorator that extracts request headers.
+ * @param key - Optional key to extract specific header
+ * @returns Parameter decorator
+ *
+ * @example
+ * ```ts
+ * @Get('/data')
+ * getData(@ReqHeader('Authorization') authHeader: string) {
+ *   // authHeader will contain the value of req.headers['authorization']
+ * }
+ * ```
+ */
+export const ReqHeader = createParamDecorator('reqHeader');
 
 /**
  * Decorator that injects the entire request object.
@@ -593,7 +793,7 @@ export function Headers(headers: Record<string, string> | string, value?: string
  * Useful for pre-processing or logging.
  *
  * @param fn - Function to execute before the handler
- * @returns Method decorator
+ * @returns Method decorator or Class decorator
  *
  * @example
  * ```ts
@@ -602,13 +802,27 @@ export function Headers(headers: Record<string, string> | string, value?: string
  * getUser(@Param('id') id: string) {
  *   // Function will log before this handler runs
  * }
+ *
+ * @Controller('/api')
+ * @Before((req, res) => console.log(`API access: ${req.path}`))
+ * class ApiController {
+ *   // Hook runs before all routes in this controller
+ * }
  * ```
  */
-export function Before(fn: Function): MethodDecorator {
-  return (target, propertyKey, _descriptor) => {
-    const hooks: Function[] = Reflect.getMetadata(BEFORE_KEY, target as object, propertyKey as string) || [];
-    hooks.push(fn);
-    Reflect.defineMetadata(BEFORE_KEY, hooks, target as object, propertyKey as string);
+export function Before(fn: Function): MethodDecorator & ClassDecorator {
+  return (target: any, propertyKey?: string | symbol, _descriptor?: PropertyDescriptor) => {
+    if (typeof propertyKey === 'undefined') {
+      // Class decorator
+      const hooks: Function[] = Reflect.getMetadata(BEFORE_KEY, target as object) || [];
+      hooks.push(fn);
+      Reflect.defineMetadata(BEFORE_KEY, hooks, target as object);
+    } else {
+      // Method decorator
+      const hooks: Function[] = Reflect.getMetadata(BEFORE_KEY, target as object, propertyKey as string) || [];
+      hooks.push(fn);
+      Reflect.defineMetadata(BEFORE_KEY, hooks, target as object, propertyKey as string);
+    }
   };
 }
 
@@ -617,7 +831,7 @@ export function Before(fn: Function): MethodDecorator {
  * Can access the handler's result.
  *
  * @param fn - Function to execute after the handler
- * @returns Method decorator
+ * @returns Method decorator or Class decorator
  *
  * @example
  * ```ts
@@ -627,13 +841,27 @@ export function Before(fn: Function): MethodDecorator {
  *   // After this handler, the function will log the returned data
  *   return { id, name: 'Example' };
  * }
+ *
+ * @Controller('/api')
+ * @After((req, res, result) => console.log(`API response: ${JSON.stringify(result)}`))
+ * class ApiController {
+ *   // Hook runs after all routes in this controller
+ * }
  * ```
  */
-export function After(fn: Function): MethodDecorator {
-  return (target, propertyKey, _descriptor) => {
-    const hooks: Function[] = Reflect.getMetadata(AFTER_KEY, target as object, propertyKey as string) || [];
-    hooks.push(fn);
-    Reflect.defineMetadata(AFTER_KEY, hooks, target as object, propertyKey as string);
+export function After(fn: Function): MethodDecorator & ClassDecorator {
+  return (target: any, propertyKey?: string | symbol, _descriptor?: PropertyDescriptor) => {
+    if (typeof propertyKey === 'undefined') {
+      // Class decorator
+      const hooks: Function[] = Reflect.getMetadata(AFTER_KEY, target as object) || [];
+      hooks.push(fn);
+      Reflect.defineMetadata(AFTER_KEY, hooks, target as object);
+    } else {
+      // Method decorator
+      const hooks: Function[] = Reflect.getMetadata(AFTER_KEY, target as object, propertyKey as string) || [];
+      hooks.push(fn);
+      Reflect.defineMetadata(AFTER_KEY, hooks, target as object, propertyKey as string);
+    }
   };
 }
 
@@ -773,7 +1001,7 @@ export function RateLimit(options: {
  * Decorator that sets the content type for the response.
  *
  * @param type - MIME type for the response
- * @returns Method decorator
+ * @returns Method decorator or Class decorator
  *
  * @example
  * ```ts
@@ -782,11 +1010,23 @@ export function RateLimit(options: {
  * downloadPdf() {
  *   return this.fileService.generatePdf();
  * }
+ *
+ * @Controller('/api/json')
+ * @ContentType('application/json')
+ * class JsonApiController {
+ *   // All routes in this controller use this content type
+ * }
  * ```
  */
-export function ContentType(type: string): MethodDecorator {
-  return (target, propertyKey, _descriptor) => {
-    Reflect.defineMetadata(CONTENT_TYPE_KEY, { type }, target, propertyKey as string);
+export function ContentType(type: string): MethodDecorator & ClassDecorator {
+  return (target: any, propertyKey?: string | symbol, _descriptor?: PropertyDescriptor) => {
+    if (typeof propertyKey === 'undefined') {
+      // Class decorator
+      Reflect.defineMetadata(CONTENT_TYPE_KEY, { type }, target as object);
+    } else {
+      // Method decorator
+      Reflect.defineMetadata(CONTENT_TYPE_KEY, { type }, target, propertyKey as string);
+    }
   };
 }
 
@@ -931,6 +1171,13 @@ export function Log(options?: {
  */
 export function registerControllers(router: Router, controllers: any[]) {
   controllers.forEach(ControllerClass => {
+    // Register the controller class with the container first (important!)
+    if (!Reflect.getMetadata('injectable', ControllerClass)) {
+      // If not already marked as injectable, register it
+      Reflect.defineMetadata('injectable', true, ControllerClass);
+      diContainer.register(ControllerClass);
+    }
+
     // Use DI container to resolve controller (constructor injection + property injection)
     const instance = diContainer.get(ControllerClass);
     const basePath: string = Reflect.getMetadata('basePath', ControllerClass as object) || '';
@@ -944,9 +1191,15 @@ export function registerControllers(router: Router, controllers: any[]) {
     const controllerRoles = Reflect.getMetadata(ROLES_KEY, ControllerClass as object);
     const controllerLogConfig = Reflect.getMetadata(LOG_KEY, ControllerClass as object);
     const controllerHeaders = Reflect.getMetadata(HEADER_KEY, ControllerClass as object) || {};
+    const controllerMiddlewares: RequestHandler[] =
+      Reflect.getMetadata(MIDDLEWARE_KEY, ControllerClass as object) || [];
+    const controllerBeforeHooks: Function[] = Reflect.getMetadata(BEFORE_KEY, ControllerClass as object) || [];
+    const controllerAfterHooks: Function[] = Reflect.getMetadata(AFTER_KEY, ControllerClass as object) || [];
+    const controllerContentType = Reflect.getMetadata(CONTENT_TYPE_KEY, ControllerClass as object);
 
     routes.forEach(({ path, method, handlerName }) => {
-      const middlewares: RequestHandler[] = Reflect.getMetadata(MIDDLEWARE_KEY, instance as object, handlerName) || [];
+      const methodMiddlewares: RequestHandler[] =
+        Reflect.getMetadata(MIDDLEWARE_KEY, instance as object, handlerName) || [];
       const params: ParamDefinition[] = Reflect.getMetadata(PARAMS_KEY, instance as object, handlerName) || [];
 
       const httpCode: number | undefined = Reflect.getMetadata(HTTP_CODE_KEY, instance as object, handlerName);
@@ -956,18 +1209,27 @@ export function registerControllers(router: Router, controllers: any[]) {
         Reflect.getMetadata(HEADER_KEY, instance as object, handlerName) || {};
       const headers = { ...controllerHeaders, ...methodHeaders };
 
-      const beforeHooks: Function[] = Reflect.getMetadata(BEFORE_KEY, instance as object, handlerName) || [];
-      const afterHooks: Function[] = Reflect.getMetadata(AFTER_KEY, instance as object, handlerName) || [];
+      // Merge controller-level and method-level middlewares
+      const middlewares = [...controllerMiddlewares, ...methodMiddlewares];
+
+      // Merge controller-level and method-level hooks
+      const methodBeforeHooks: Function[] = Reflect.getMetadata(BEFORE_KEY, instance as object, handlerName) || [];
+      const methodAfterHooks: Function[] = Reflect.getMetadata(AFTER_KEY, instance as object, handlerName) || [];
+      const beforeHooks = [...controllerBeforeHooks, ...methodBeforeHooks];
+      const afterHooks = [...methodAfterHooks, ...controllerAfterHooks]; // Method hooks should run first, then class hooks
+
       const redirect: { url?: string; statusCode: number } | undefined = Reflect.getMetadata(
         REDIRECT_KEY,
         instance as object,
         handlerName
       );
-      const contentType: { type: string } | undefined = Reflect.getMetadata(
+      const methodContentType: { type: string } | undefined = Reflect.getMetadata(
         CONTENT_TYPE_KEY,
         instance as object,
         handlerName
       );
+      // Method content type overrides controller content type
+      const contentType = methodContentType || controllerContentType;
 
       // Use method-level decorators if present, otherwise fall back to controller-level
       const roles: string[] = Reflect.getMetadata(ROLES_KEY, instance as object, handlerName) || controllerRoles || [];
@@ -1099,13 +1361,16 @@ export function registerControllers(router: Router, controllers: any[]) {
           for (const fn of beforeHooks) await fn(req, res);
           const args: any[] = [];
           if (params.length) {
-            params.forEach(({ index, type, key }) => {
+            params.forEach(({ index, type, key, options }) => {
+              let rawValue: any;
               switch (type) {
                 case 'query':
-                  args[index] = key ? req.query[key] : req.query;
+                  rawValue = key ? req.query[key] : req.query;
+                  args[index] = options ? applyParamOptions(rawValue, options, key) : rawValue;
                   break;
                 case 'param':
-                  args[index] = key ? req.params[key] : req.params;
+                  rawValue = key ? req.params[key] : req.params;
+                  args[index] = options ? applyParamOptions(rawValue, options, key) : rawValue;
                   break;
                 case 'body':
                   args[index] = key ? req.body?.[key] : req.body;
@@ -1115,6 +1380,12 @@ export function registerControllers(router: Router, controllers: any[]) {
                   break;
                 case 'res':
                   args[index] = res;
+                  break;
+                case 'logger':
+                  args[index] = getLogger();
+                  break;
+                case 'reqHeader':
+                  args[index] = key ? req.headers[key.toLowerCase()] : req.headers;
                   break;
               }
             });
@@ -1173,4 +1444,204 @@ export function registerControllers(router: Router, controllers: any[]) {
       (router as any)[method](basePath + finalPath, ...middlewares, handler);
     });
   });
+}
+
+// Helper for type conversion and ParamOptions handling
+function applyParamOptions(rawValue: any, options: ParamOptions, key?: string) {
+  if (!options) return rawValue;
+
+  let value = rawValue;
+  const paramName = key ? `: ${key}` : '';
+
+  // Handle default value for undefined, null, or empty strings
+  if (value === undefined || value === null || value === '') {
+    if ('default' in options) {
+      value = options.default;
+    }
+  }
+
+  // Required check
+  if (options.required && (value === undefined || value === null || value === '')) {
+    throw new BadRequestException(`Required parameter missing${paramName}`);
+  }
+
+  // Apply type conversions only if value is defined
+  if (value !== undefined && value !== null) {
+    if (options.dataType === 'array') {
+      // Handle array data type
+      const delimiter = options.delimiter || ',';
+      if (typeof value === 'string') {
+        value = value.split(delimiter).map(v => v.trim());
+      } else if (!Array.isArray(value)) {
+        value = [value];
+      }
+
+      // Pattern check
+      if (options.type === 'string' && options.pattern) {
+        const hasInvalidPattern = value.some((v: any) => !options.pattern!.test(v));
+        if (hasInvalidPattern) {
+          throw new BadRequestException(
+            `Parameter '${key}' array contains values that do not match pattern: ${options.patternName || options.pattern}`
+          );
+        }
+      }
+
+      // Handle number pattern validation
+      if (options.type === 'number' && options.pattern) {
+        const hasInvalidPattern = value.some((v: any) => !options.pattern!.test(String(v)));
+        if (hasInvalidPattern) {
+          throw new BadRequestException(
+            `Parameter '${key}' array contains values that do not match pattern: ${options.patternName || options.pattern}`
+          );
+        }
+      }
+
+      // Validate array elements BEFORE conversion for better error messages
+      if (options.type === 'number' && options.throwError !== false) {
+        const hasInvalidNumber = value.some((v: any) => isNaN(Number(v)));
+        if (hasInvalidNumber) {
+          throw new BadRequestException(`Type error: expected number array${paramName}`);
+        }
+        if (options.min !== undefined) {
+          const hasBelowMin = value.some((v: any) => Number(v) < options.min!);
+          if (hasBelowMin) {
+            throw new BadRequestException(
+              `Validation error: number array values must be >= ${options.min}${paramName}`
+            );
+          }
+        }
+        if (options.max !== undefined) {
+          const hasAboveMax = value.some((v: any) => Number(v) > options.max!);
+          if (hasAboveMax) {
+            throw new BadRequestException(
+              `Validation error: number array values must be <= ${options.max}${paramName}`
+            );
+          }
+        }
+      }
+
+      if (options.type === 'boolean' && options.throwError !== false) {
+        const hasInvalidBoolean = value.some((v: any) => !isValidBooleanInput(v));
+        if (hasInvalidBoolean) {
+          throw new BadRequestException(`Type error: expected boolean array${paramName}`);
+        }
+      }
+
+      // Apply type conversion to each array element
+      if (options.type) {
+        value = value.map((v: any) => convertType(v, options.type));
+      }
+    } else if (options.dataType === 'object') {
+      // Handle object data type
+      if (typeof value === 'string') {
+        try {
+          value = JSON.parse(value);
+        } catch (_e) {
+          if (options.throwError !== false) {
+            throw new BadRequestException(`Invalid JSON object${paramName}`);
+          }
+        }
+      }
+    } else if (options.type) {
+      // Handle simple type conversion for non-array/object values
+      const originalValue = value;
+      value = convertType(value, options.type);
+
+      if (options.throwError === false) {
+        if (options.type === 'number' && typeof value === 'number') {
+          if (options.min !== undefined && value < options.min) {
+            value = undefined;
+          }
+          if (options.max !== undefined && value > options.max) {
+            value = undefined;
+          }
+        }
+      }
+
+      if (options.type === 'string' && options.pattern && typeof value === 'string' && !options.pattern.test(value)) {
+        throw new BadRequestException(
+          `Parameter '${key}' does not match pattern: ${options.patternName || options.pattern}`
+        );
+      } else if (
+        options.type === 'number' &&
+        options.pattern &&
+        typeof value === 'number' &&
+        !options.pattern.test(String(value))
+      ) {
+        throw new BadRequestException(
+          `Parameter '${key}' does not match pattern: ${options.patternName || options.pattern}`
+        );
+      }
+
+      // Check for type conversion errors
+      if (options.throwError !== false) {
+        if (options.type === 'number' && typeof value === 'number' && isNaN(value)) {
+          throw new BadRequestException(`Type error: expected number${paramName}`);
+        }
+
+        if (options.type === 'number' && typeof value === 'number') {
+          if (options.min !== undefined && value < options.min) {
+            throw new BadRequestException(`Validation error: number must be >= ${options.min}${paramName}`);
+          }
+          if (options.max !== undefined && value > options.max) {
+            throw new BadRequestException(`Validation error: number must be <= ${options.max}${paramName}`);
+          }
+        }
+
+        // Check for boolean type validation
+        if (options.type === 'boolean' && !isValidBooleanInput(originalValue)) {
+          throw new BadRequestException(`Type error: expected boolean${paramName}`);
+        }
+      }
+    }
+  }
+
+  // Apply transform function if provided
+  if (options.transform && typeof options.transform === 'function') {
+    value = options.transform(value);
+  }
+
+  // Apply validation if provided
+  if (options.validate && typeof options.validate === 'function') {
+    if (!options.validate(value)) {
+      if (options.throwError !== false) {
+        throw new BadRequestException(`Parameter validation failed${paramName}`);
+      }
+      return undefined;
+    }
+  }
+
+  return value;
+}
+
+// Helper function to validate boolean inputs
+function isValidBooleanInput(value: any): boolean {
+  if (typeof value === 'boolean') return true;
+  if (typeof value === 'number') return value === 0 || value === 1;
+  if (typeof value === 'string') {
+    const normalizedValue = value.toLowerCase().trim();
+    return ['true', 'false', '0', '1', 'yes', 'no'].includes(normalizedValue);
+  }
+  return false;
+}
+
+// Update the convertType function to be more robust
+function convertType(value: any, type: 'string' | 'number' | 'boolean') {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  switch (type) {
+    case 'number':
+      return Number(value);
+    case 'boolean':
+      if (typeof value === 'string') {
+        const normalizedValue = value.toLowerCase().trim();
+        return normalizedValue === 'true' || normalizedValue === '1' || normalizedValue === 'yes';
+      }
+      return value === true || value === 1;
+    case 'string':
+    default:
+      return String(value);
+  }
 }

--- a/src/utils/logger.utils.ts
+++ b/src/utils/logger.utils.ts
@@ -36,7 +36,7 @@ const GLOBAL_LOGGER_KEY = Symbol.for('logger');
 /**
  * Logger type for application-wide logging.
  */
-export type Logger = pino.Logger;
+export type Logger = PinoLogger;
 
 /**
  * Logger levels for application-wide logging.
@@ -232,7 +232,7 @@ const _global = _globalThis as unknown as { [GLOBAL_LOGGER_KEY]: PinoLogger };
  * - Sets log name, level, timestamp, and redaction for sensitive fields.
  * - Uses singleton in global symbol registry.
  */
-function setupLogger(): void {
+function setupLogger(isGlobal: boolean = true): PinoLogger {
   const logParams: LoggerOptions = {
     name: config.logger.name || '@catbee/utils',
     level: config.logger.level || 'info',
@@ -240,14 +240,14 @@ function setupLogger(): void {
       paths: ['req.authorization', 'res.authorization', 'url', 'headers.authorization', 'headers.cookies'],
       censor: (value, path) => redact(value, path)
     },
-    // serializers: {
-    //   req: pino.stdSerializers.req,
-    //   request: pino.stdSerializers.req,
-    //   res: pino.stdSerializers.res,
-    //   response: pino.stdSerializers.res,
-    //   err: pino.stdSerializers.err,
-    //   error: pino.stdSerializers.err
-    // },
+    serializers: {
+      req: pino.stdSerializers.req,
+      request: pino.stdSerializers.req,
+      res: pino.stdSerializers.res,
+      response: pino.stdSerializers.res,
+      err: pino.stdSerializers.err,
+      error: pino.stdSerializers.err
+    },
     timestamp: stdTimeFunctions.isoTime
   };
 
@@ -268,8 +268,12 @@ function setupLogger(): void {
         )
       : pino(logParams);
 
-  _global[GLOBAL_LOGGER_KEY] = logger;
-  _global[GLOBAL_LOGGER_KEY]?.debug('Logger initialized');
+  if (isGlobal) {
+    _global[GLOBAL_LOGGER_KEY] = logger;
+    _global[GLOBAL_LOGGER_KEY]?.debug('Logger initialized');
+  }
+
+  return logger;
 }
 
 /**
@@ -277,10 +281,16 @@ function setupLogger(): void {
  * - Returns a request-scoped logger from AsyncLocalStorage if available
  * - Falls back to the global (singleton) logger
  * - Initializes the global logger if not created yet
+ * - If newInstance is true, returns a fresh logger without any context
  *
- * @returns {Logger} The logger instance (request-bound or global root logger)
+ * @param {boolean} newInstance - If true, returns a fresh logger without any context
+ * @returns {Logger} The logger instance (request-bound or global root logger or fresh instance)
  */
-export function getLogger(): PinoLogger {
+export function getLogger(newInstance: boolean = false): PinoLogger {
+  if (newInstance) {
+    return setupLogger(false);
+  }
+
   const logger = ContextStore.get<PinoLogger>(StoreKeys.LOGGER);
   if (logger) return logger;
 
@@ -292,10 +302,10 @@ export function getLogger(): PinoLogger {
 }
 
 /**
- * Logger instance for the global context.
+ * Returns a fresh logger instance without any request context.
  * This logger is used for logging messages that are not tied to a specific request.
  */
-export const logger = getLogger();
+export const logger = getLogger(false);
 
 /**
  * Creates a child logger with additional context.

--- a/tests/utils/decorator.utils.test.ts
+++ b/tests/utils/decorator.utils.test.ts
@@ -26,7 +26,8 @@ import {
   Log,
   registerControllers,
   Injectable,
-  Inject
+  Inject,
+  ReqHeader
 } from '../../src/utils/decorators.utils';
 import { jest } from '@jest/globals';
 import { HttpStatusCodes } from '../../src/utils/http-status-codes';
@@ -1384,6 +1385,1119 @@ describe('Decorators and registerControllers', () => {
 
       expect(mockRes.json).not.toHaveBeenCalled();
       expect(mockRes.status).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Parameter Options Tests', () => {
+    beforeEach(() => {
+      mockRouter = createMockRouter();
+      mockReq = {
+        method: 'GET',
+        originalUrl: '/api/params-test',
+        url: '/params-test',
+        query: {
+          stringVal: 'test',
+          numberVal: '42',
+          boolVal: 'true',
+          arrayVal: '1,2,3',
+          customArray: '1|2|3',
+          emptyVal: '',
+          objectVal: '{"name":"John","age":30}',
+          invalidJson: '{name:John}'
+        },
+        params: {
+          stringId: 'abc123',
+          numberId: '987',
+          boolId: 'false',
+          missingVal: undefined
+        },
+        body: {
+          string: 'body-test',
+          number: 42,
+          boolean: true,
+          nested: {
+            value: 'nested-value'
+          },
+          array: [1, 2, 3]
+        },
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer token123',
+          'x-api-key': 'abc123',
+          'accept-language': 'en-US,en;q=0.9'
+        }
+      } as any;
+      mockRes = {
+        json: jest.fn(),
+        send: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        setHeader: jest.fn().mockReturnThis()
+      } as unknown as Response;
+      mockNext = jest.fn();
+    });
+
+    it('should apply string type conversion', async () => {
+      @Controller('/params')
+      class StringParamsController {
+        @Get('/string')
+        testString(
+          @Query('numberVal', { type: 'string' }) numberAsString: string,
+          @Param('numberId', { type: 'string' }) idAsString: string,
+          @Body('number') bodyNumberAsString: any // Remove type option from Body
+        ) {
+          return {
+            numberAsString,
+            idAsString,
+            bodyNumberAsString,
+            numberAsStringType: typeof numberAsString,
+            idAsStringType: typeof idAsString,
+            bodyNumberAsStringType: typeof bodyNumberAsString
+          };
+        }
+      }
+
+      registerControllers(mockRouter, [StringParamsController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        numberAsString: '42',
+        idAsString: '987',
+        bodyNumberAsString: 42,
+        numberAsStringType: 'string',
+        idAsStringType: 'string',
+        bodyNumberAsStringType: 'number'
+      });
+    });
+
+    it('should apply number type conversion', async () => {
+      @Controller('/params')
+      class NumberParamsController {
+        @Get('/number')
+        testNumber(
+          @Query('numberVal', { type: 'number' }) num: number,
+          @Param('numberId', { type: 'number' }) id: number,
+          @Body('string') invalidNumber: any
+        ) {
+          return {
+            num,
+            id,
+            invalidNumber,
+            numType: typeof num,
+            idType: typeof id,
+            invalidNumberType: typeof invalidNumber
+          };
+        }
+      }
+
+      registerControllers(mockRouter, [NumberParamsController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        num: 42,
+        id: 987,
+        invalidNumber: 'body-test',
+        numType: 'number',
+        idType: 'number',
+        invalidNumberType: 'string' // Type is now string, not number
+      });
+    });
+
+    it('should apply boolean type conversion', async () => {
+      @Controller('/params')
+      class BooleanParamsController {
+        @Get('/boolean')
+        testBoolean(
+          @Query('boolVal', { type: 'boolean' }) queryBool: boolean,
+          @Param('boolId', { type: 'boolean' }) paramBool: boolean,
+          @Body('boolean') bodyBool: any
+        ) {
+          return {
+            queryBool,
+            paramBool,
+            bodyBool,
+            queryBoolType: typeof queryBool,
+            paramBoolType: typeof paramBool,
+            bodyBoolType: typeof bodyBool
+          };
+        }
+      }
+
+      registerControllers(mockRouter, [BooleanParamsController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        queryBool: true,
+        paramBool: false,
+        bodyBool: true,
+        queryBoolType: 'boolean',
+        paramBoolType: 'boolean',
+        bodyBoolType: 'boolean'
+      });
+    });
+
+    it('should handle array type conversion with default delimiter', async () => {
+      @Controller('/params')
+      class ArrayParamsController {
+        @Get('/array')
+        testArray(
+          @Query('arrayVal', { type: 'number', dataType: 'array' }) numberArray: number[],
+          @Body('array') bodyArray: any
+        ) {
+          return {
+            numberArray,
+            stringArray: bodyArray,
+            numberArrayType: typeof numberArray,
+            stringArrayType: typeof bodyArray,
+            isNumberArray: Array.isArray(numberArray),
+            isStringArray: Array.isArray(bodyArray)
+          };
+        }
+      }
+
+      registerControllers(mockRouter, [ArrayParamsController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        numberArray: [1, 2, 3],
+        stringArray: [1, 2, 3], // Still an array but without string conversion
+        numberArrayType: 'object',
+        stringArrayType: 'object',
+        isNumberArray: true,
+        isStringArray: true
+      });
+    });
+
+    it('should handle array type with custom delimiter', async () => {
+      @Controller('/params')
+      class CustomDelimiterController {
+        @Get('/delimiter')
+        testDelimiter(
+          @Query('customArray', { type: 'number', dataType: 'array', delimiter: '|' }) customArray: number[]
+        ) {
+          return { customArray };
+        }
+      }
+
+      registerControllers(mockRouter, [CustomDelimiterController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        customArray: [1, 2, 3]
+      });
+    });
+
+    it('should apply default values for missing parameters', async () => {
+      @Controller('/params')
+      class DefaultValueController {
+        @Get('/defaults')
+        testDefaults(
+          @Query('missingQuery', { default: 'default-query' }) defaultQuery: string,
+          @Param('missingVal', { default: 'default-param' }) defaultParam: string,
+          @Body('missingProp') defaultBody: any,
+          @Query('emptyVal', { default: 'default-for-empty' }) defaultForEmpty: string
+        ) {
+          return {
+            defaultQuery,
+            defaultParam,
+            defaultBody,
+            defaultForEmpty
+          };
+        }
+      }
+
+      registerControllers(mockRouter, [DefaultValueController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        defaultQuery: 'default-query',
+        defaultParam: 'default-param',
+        defaultBody: undefined,
+        defaultForEmpty: 'default-for-empty'
+      });
+    });
+
+    it('should throw error for missing required parameters', async () => {
+      @Controller('/params')
+      class RequiredParamsController {
+        @Get('/required')
+        testRequired(@Query('missingQuery', { required: true }) requiredQuery: string) {
+          return { success: true };
+        }
+      }
+
+      registerControllers(mockRouter, [RequiredParamsController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockNext.mock.calls[0][0].message).toBe('Required parameter missing: missingQuery');
+      expect(mockRes.json).not.toHaveBeenCalled();
+    });
+
+    it('should throw error for missing required parameters even when throwError is false', async () => {
+      @Controller('/params')
+      class SilentRequiredParamsController {
+        @Get('/silent-required')
+        testSilentRequired(@Query('missingQuery', { required: true, throwError: false }) requiredQuery: string) {
+          return { requiredQuery };
+        }
+      }
+
+      registerControllers(mockRouter, [SilentRequiredParamsController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it('should apply custom validation functions', async () => {
+      @Controller('/params')
+      class ValidationController {
+        @Get('/validation')
+        testValidation(
+          @Query('numberVal', {
+            validate: val => Number(val) > 40 && Number(val) < 50
+          })
+          validNumber: string,
+          @Query('stringVal', {
+            validate: val => val.length > 10,
+            throwError: false
+          })
+          invalidString: string
+        ) {
+          return { validNumber, invalidString };
+        }
+      }
+
+      registerControllers(mockRouter, [ValidationController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        validNumber: '42',
+        invalidString: undefined // validation failed, but throwError is false
+      });
+    });
+
+    it('should throw error when validation fails and throwError is true', async () => {
+      @Controller('/params')
+      class FailingValidationController {
+        @Get('/failing-validation')
+        testFailingValidation(
+          @Query('stringVal', {
+            validate: val => val.length > 10
+          })
+          invalidString: string
+        ) {
+          return { invalidString };
+        }
+      }
+
+      registerControllers(mockRouter, [FailingValidationController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockNext.mock.calls[0][0].message).toBe('Parameter validation failed: stringVal');
+      expect(mockRes.json).not.toHaveBeenCalled();
+    });
+
+    it('should apply custom transform functions', async () => {
+      @Controller('/params')
+      class TransformController {
+        @Get('/transform')
+        testTransform(
+          @Query('numberVal', {
+            transform: val => Number(val) * 2
+          })
+          doubledNumber: number,
+          @Query('stringVal', {
+            transform: val => val.toUpperCase()
+          })
+          uppercaseString: string,
+          @Body('nested') nestedValue: any
+        ) {
+          return {
+            doubledNumber,
+            uppercaseString,
+            transformedNested: nestedValue ? nestedValue.value + '-transformed' : undefined
+          };
+        }
+      }
+
+      registerControllers(mockRouter, [TransformController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        doubledNumber: 84,
+        uppercaseString: 'TEST',
+        transformedNested: 'nested-value-transformed' // Transformation done manually
+      });
+    });
+
+    it('should handle complex combinations of options', async () => {
+      @Controller('/params')
+      class ComplexParamsController {
+        @Get('/complex')
+        testComplex(
+          @Query('arrayVal', {
+            type: 'number',
+            dataType: 'array',
+            transform: arr => arr.map((n: number) => n * 10),
+            validate: arr => arr.every((n: number) => n > 5)
+          })
+          transformedArray: number[],
+          @Body('nested') nestedObject: any
+        ) {
+          const transformedObject = nestedObject ? { ...nestedObject, extra: 'added' } : { fallback: true };
+
+          return {
+            transformedArray,
+            transformedObject
+          };
+        }
+      }
+
+      registerControllers(mockRouter, [ComplexParamsController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        transformedArray: [10, 20, 30],
+        transformedObject: {
+          value: 'nested-value',
+          extra: 'added'
+        }
+      });
+    });
+
+    it('should handle edge cases and null values', async () => {
+      // Update mockReq to include edge cases
+      mockReq.query.nullValue = null;
+      mockReq.body.nullValue = null;
+
+      @Controller('/params')
+      class EdgeCaseController {
+        @Get('/edge-cases')
+        testEdgeCases(
+          @Query('nullValue', { default: 'null-default' }) nullQueryWithDefault: string,
+          @Query('undefinedValue', { type: 'number', default: 999 }) undefinedWithDefault: number,
+          @Body('nullValue') nullBodyValue: any
+        ) {
+          return {
+            nullQueryWithDefault,
+            nullBodyWithDefault: nullBodyValue === null ? true : nullBodyValue,
+            undefinedWithDefault
+          };
+        }
+      }
+
+      registerControllers(mockRouter, [EdgeCaseController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        nullQueryWithDefault: 'null-default',
+        nullBodyWithDefault: true,
+        undefinedWithDefault: 999
+      });
+    });
+
+    it('should handle arrays passed directly in query/body', async () => {
+      // Update mockReq to include direct arrays
+      mockReq.query.directArray = ['a', 'b', 'c'];
+      mockReq.body.directArray = [1, 2, 3];
+
+      @Controller('/params')
+      class DirectArrayController {
+        @Get('/direct-arrays')
+        testDirectArrays(
+          @Query('directArray', { type: 'string', dataType: 'array' }) queryArray: string[],
+          @Body('directArray') bodyArray: any
+        ) {
+          return {
+            queryArray,
+            bodyArray
+          };
+        }
+      }
+
+      registerControllers(mockRouter, [DirectArrayController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        queryArray: ['a', 'b', 'c'],
+        bodyArray: [1, 2, 3]
+      });
+    });
+
+    it('should handle non-string values in type conversion', async () => {
+      // Update mockReq with non-string values
+      mockReq.query.numberObject = 42;
+      mockReq.query.booleanObject = true;
+
+      @Controller('/params')
+      class NonStringController {
+        @Get('/non-string')
+        testNonString(
+          @Query('numberObject', { type: 'string' }) numberAsString: string,
+          @Query('booleanObject', { type: 'string' }) booleanAsString: string
+        ) {
+          return {
+            numberAsString,
+            booleanAsString,
+            numberAsStringType: typeof numberAsString,
+            booleanAsStringType: typeof booleanAsString
+          };
+        }
+      }
+
+      registerControllers(mockRouter, [NonStringController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        numberAsString: '42',
+        booleanAsString: 'true',
+        numberAsStringType: 'string',
+        booleanAsStringType: 'string'
+      });
+    });
+
+    it('should extract headers with @ReqHeader decorator', async () => {
+      @Controller('/headers')
+      class HeadersExtractController {
+        @Get('/extract')
+        testHeaders(
+          @ReqHeader('authorization') auth: string,
+          @ReqHeader('x-api-key') apiKey: string,
+          @ReqHeader('content-type') contentType: string,
+          @ReqHeader() allHeaders: any,
+          @ReqHeader('non-existent') missingHeader: string
+        ) {
+          return {
+            auth,
+            apiKey,
+            contentType,
+            acceptLanguage: allHeaders['accept-language'],
+            missingHeader
+          };
+        }
+      }
+
+      registerControllers(mockRouter, [HeadersExtractController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        auth: 'Bearer token123',
+        apiKey: 'abc123',
+        contentType: 'application/json',
+        acceptLanguage: 'en-US,en;q=0.9',
+        missingHeader: undefined
+      });
+    });
+
+    it('should handle case-insensitive headers with @ReqHeader decorator', async () => {
+      @Controller('/headers')
+      class CaseSensitiveHeadersController {
+        @Get('/case-insensitive')
+        testCaseInsensitive(
+          @ReqHeader('CONTENT-TYPE') uppercaseHeader: string,
+          @ReqHeader('Authorization') mixedCaseHeader: string
+        ) {
+          return {
+            uppercaseHeader,
+            mixedCaseHeader
+          };
+        }
+      }
+
+      registerControllers(mockRouter, [CaseSensitiveHeadersController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        uppercaseHeader: 'application/json',
+        mixedCaseHeader: 'Bearer token123'
+      });
+    });
+  });
+
+  describe('Parameter Validation Error Tests', () => {
+    beforeEach(() => {
+      mockRouter = createMockRouter();
+      mockReq = {
+        method: 'GET',
+        originalUrl: '/api/validation-test',
+        url: '/validation-test',
+        query: {
+          validNumber: '123',
+          invalidNumber: 'not-a-number',
+          arrayWithInvalidNumber: '1,two,3',
+          validBoolean: 'true',
+          invalidBoolean: 'not-a-boolean',
+          arrayWithInvalidBoolean: 'true,maybe,false',
+          validBoolStrings: ['true', 'yes', '1', 'false', 'no', '0']
+        },
+        params: {},
+        body: {},
+        headers: {}
+      } as any;
+      mockRes = {
+        json: jest.fn(),
+        send: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        setHeader: jest.fn().mockReturnThis()
+      } as unknown as Response;
+      mockNext = jest.fn();
+    });
+
+    it('should throw error for invalid number parameter', async () => {
+      @Controller('/validation')
+      class NumberValidationController {
+        @Get('/number')
+        testInvalidNumber(@Query('invalidNumber', { type: 'number' }) num: number) {
+          return { num };
+        }
+      }
+
+      registerControllers(mockRouter, [NumberValidationController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockNext.mock.calls[0][0].message).toBe('Type error: expected number: invalidNumber');
+    });
+
+    it('should throw error for invalid boolean parameter', async () => {
+      @Controller('/validation')
+      class BooleanValidationController {
+        @Get('/boolean')
+        testInvalidBoolean(@Query('invalidBoolean', { type: 'boolean' }) bool: boolean) {
+          return { bool };
+        }
+      }
+
+      registerControllers(mockRouter, [BooleanValidationController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockNext.mock.calls[0][0].message).toBe('Type error: expected boolean: invalidBoolean');
+    });
+
+    it('should throw error for array with invalid number elements', async () => {
+      @Controller('/validation')
+      class ArrayNumberValidationController {
+        @Get('/array-number')
+        testInvalidArrayNumber(
+          @Query('arrayWithInvalidNumber', { type: 'number', dataType: 'array' }) numbers: number[]
+        ) {
+          return { numbers };
+        }
+      }
+
+      registerControllers(mockRouter, [ArrayNumberValidationController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockNext.mock.calls[0][0].message).toBe('Type error: expected number array: arrayWithInvalidNumber');
+    });
+
+    it('should throw error for array with invalid boolean elements', async () => {
+      @Controller('/validation')
+      class ArrayBooleanValidationController {
+        @Get('/array-boolean')
+        testInvalidArrayBoolean(
+          @Query('arrayWithInvalidBoolean', { type: 'boolean', dataType: 'array' }) booleans: boolean[]
+        ) {
+          return { booleans };
+        }
+      }
+
+      registerControllers(mockRouter, [ArrayBooleanValidationController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockNext.mock.calls[0][0].message).toBe('Type error: expected boolean array: arrayWithInvalidBoolean');
+    });
+
+    it('should not throw error when throwError is false', async () => {
+      @Controller('/validation')
+      class NoErrorController {
+        @Get('/no-error')
+        testNoError(
+          @Query('invalidNumber', { type: 'number', throwError: false }) num: number,
+          @Query('invalidBoolean', { type: 'boolean', throwError: false }) bool: boolean
+        ) {
+          return { num, bool };
+        }
+      }
+
+      registerControllers(mockRouter, [NoErrorController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockRes.json).toHaveBeenCalledWith({
+        // Values will be NaN and false but not trigger errors
+        num: NaN,
+        bool: false
+      });
+    });
+
+    it('should handle different valid string representations of boolean values', async () => {
+      @Controller('/validation')
+      class BooleanStringsController {
+        @Get('/boolean-strings')
+        testBooleanStrings(@Query('validBoolStrings', { type: 'boolean', dataType: 'array' }) booleans: boolean[]) {
+          return { booleans };
+        }
+      }
+
+      registerControllers(mockRouter, [BooleanStringsController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockRes.json).toHaveBeenCalledWith({
+        booleans: [true, true, true, false, false, false]
+      });
+    });
+
+    it('should validate number min/max constraints', async () => {
+      mockReq.query = {
+        validNumber: '50',
+        belowMin: '5',
+        aboveMax: '105'
+      };
+
+      @Controller('/validation')
+      class NumberConstraintController {
+        @Get('/min-max')
+        testMinMax(
+          @Query('validNumber', { type: 'number', min: 10, max: 100 }) validNumber: number,
+          @Query('belowMin', { type: 'number', min: 10, max: 100 }) belowMin: number,
+          @Query('aboveMax', { type: 'number', min: 10, max: 100 }) aboveMax: number
+        ) {
+          return { validNumber, belowMin, aboveMax };
+        }
+      }
+
+      registerControllers(mockRouter, [NumberConstraintController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0].message).toBe('Validation error: number must be >= 10: belowMin');
+
+      // Reset for next test
+      mockNext.mockReset();
+
+      // Test above max
+      await routeHandler({ ...mockReq, query: { validNumber: '50', aboveMax: '105' } }, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0].message).toBe('Validation error: number must be <= 100: aboveMax');
+    });
+
+    it('should validate number array min/max constraints', async () => {
+      mockReq.query = {
+        validArray: '20,30,40',
+        invalidBelowMin: '5,30,40',
+        invalidAboveMax: '20,30,110'
+      };
+
+      @Controller('/validation')
+      class ArrayConstraintController {
+        @Get('/array-min-max')
+        testArrayMinMax(
+          @Query('validArray', { type: 'number', dataType: 'array', min: 10, max: 100 }) validArray: number[],
+          @Query('invalidBelowMin', { type: 'number', dataType: 'array', min: 10, max: 100 }) invalidBelowMin: number[],
+          @Query('invalidAboveMax', { type: 'number', dataType: 'array', min: 10, max: 100 }) invalidAboveMax: number[]
+        ) {
+          return { validArray, invalidBelowMin, invalidAboveMax };
+        }
+      }
+
+      registerControllers(mockRouter, [ArrayConstraintController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0].message).toBe(
+        'Validation error: number array values must be >= 10: invalidBelowMin'
+      );
+
+      // Reset for next test
+      mockNext.mockReset();
+
+      // Test above max
+      await routeHandler(
+        { ...mockReq, query: { validArray: '20,30,40', invalidAboveMax: '20,30,110' } },
+        mockRes,
+        mockNext
+      );
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0].message).toBe(
+        'Validation error: number array values must be <= 100: invalidAboveMax'
+      );
+    });
+
+    it('should apply min/max with throwError: false option', async () => {
+      mockReq.query = {
+        belowMin: '5',
+        aboveMax: '105'
+      };
+
+      @Controller('/validation')
+      class NoThrowConstraintController {
+        @Get('/no-throw-min-max')
+        testNoThrow(
+          @Query('belowMin', { type: 'number', min: 10, max: 100, throwError: false }) belowMin: number,
+          @Query('aboveMax', { type: 'number', min: 10, max: 100, throwError: false }) aboveMax: number
+        ) {
+          return { belowMin, aboveMax };
+        }
+      }
+
+      registerControllers(mockRouter, [NoThrowConstraintController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockRes.json).toHaveBeenCalledWith({
+        belowMin: undefined,
+        aboveMax: undefined
+      });
+    });
+
+    it('should apply min/max with default values', async () => {
+      mockReq.query = {
+        // Empty query
+      };
+
+      @Controller('/validation')
+      class DefaultWithConstraintController {
+        @Get('/default-with-constraint')
+        testDefaultWithConstraint(
+          @Query('missingValue', { type: 'number', min: 10, max: 100, default: 50 }) withDefault: number,
+          @Query('missingValue2', { type: 'number', min: 10, max: 100, default: 5 }) invalidDefault: number
+        ) {
+          return { withDefault, invalidDefault };
+        }
+      }
+
+      registerControllers(mockRouter, [DefaultWithConstraintController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      // Should validate the default value against min constraint
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0].message).toBe('Validation error: number must be >= 10: missingValue2');
+    });
+
+    it('should apply min/max with transform function', async () => {
+      mockReq.query = {
+        transformedNumber: '15'
+      };
+
+      @Controller('/validation')
+      class TransformWithConstraintController {
+        @Get('/transform-with-constraint')
+        testTransformWithConstraint(
+          @Query('transformedNumber', {
+            type: 'number',
+            min: 10,
+            max: 100,
+            transform: (val: number) => val * 2
+          })
+          transformedNumber: number
+        ) {
+          return { transformedNumber };
+        }
+      }
+
+      registerControllers(mockRouter, [TransformWithConstraintController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockRes.json).toHaveBeenCalledWith({
+        transformedNumber: 30 // 15 * 2 = 30
+      });
+
+      // Test with a value that would be below min after transform
+      await routeHandler({ ...mockReq, query: { transformedNumber: '4' } }, mockRes, mockNext);
+
+      // The validation happens after transform, so 4 * 2 = 8, which is below min: 10
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0].message).toBe('Validation error: number must be >= 10: transformedNumber');
+    });
+
+    it('should validate string pattern matching', async () => {
+      mockReq.query = {
+        validEmail: 'test@example.com',
+        invalidEmail: 'not-an-email',
+        zipCode: '12345',
+        invalidZip: '1234'
+      };
+
+      @Controller('/validation')
+      class PatternMatchingController {
+        @Get('/pattern-match')
+        testPatternMatch(
+          @Query('validEmail', {
+            pattern: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
+          })
+          validEmail: string,
+          @Query('invalidEmail', {
+            pattern: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
+          })
+          invalidEmail: string,
+          @Query('zipCode', {
+            pattern: /^\d{5}$/
+          })
+          zipCode: string,
+          @Query('invalidZip', {
+            pattern: /^\d{5}$/
+          })
+          invalidZip: string
+        ) {
+          return { validEmail, invalidEmail, zipCode, invalidZip };
+        }
+      }
+
+      registerControllers(mockRouter, [PatternMatchingController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockNext.mock.calls[0][0].message).toBe(
+        `Parameter 'invalidEmail' does not match pattern: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$/`
+      );
+    });
+
+    it('should validate string pattern matching even with throwError: false', async () => {
+      mockReq.query = {
+        validEmail: 'test@example.com',
+        invalidEmail: 'not-an-email'
+      };
+
+      @Controller('/validation')
+      class NoThrowPatternController {
+        @Get('/no-throw-pattern')
+        testNoThrowPattern(
+          @Query('validEmail', {
+            pattern: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+            throwError: false
+          })
+          validEmail: string,
+          @Query('invalidEmail', {
+            pattern: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+            throwError: false
+          })
+          invalidEmail: string
+        ) {
+          return { validEmail, invalidEmail };
+        }
+      }
+
+      registerControllers(mockRouter, [NoThrowPatternController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockNext.mock.calls[0][0].message).toBe(
+        `Parameter 'invalidEmail' does not match pattern: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$/`
+      );
+    });
+
+    it('should validate array of strings with pattern', async () => {
+      mockReq.query = {
+        validEmails: 'test@example.com,admin@example.com,user@test.org',
+        invalidEmails: 'test@example.com,invalid-email,user@test.org'
+      };
+
+      @Controller('/validation')
+      class ArrayPatternController {
+        @Get('/array-pattern')
+        testArrayPattern(
+          @Query('validEmails', {
+            pattern: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+            dataType: 'array'
+          })
+          validEmails: string[],
+          @Query('invalidEmails', {
+            pattern: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+            dataType: 'array'
+          })
+          invalidEmails: string[]
+        ) {
+          return { validEmails, invalidEmails };
+        }
+      }
+
+      registerControllers(mockRouter, [ArrayPatternController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0].message).toBe(
+        `Parameter 'invalidEmails' array contains values that do not match pattern: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$/`
+      );
+    });
+
+    it('should validate pattern with string type conversion', async () => {
+      mockReq.query = {
+        numericId: 12345,
+        invalidNumericId: 123
+      };
+
+      @Controller('/validation')
+      class TypePatternController {
+        @Get('/type-pattern')
+        testTypePattern(
+          @Query('numericId', {
+            type: 'string',
+            pattern: /^\d{5}$/
+          })
+          numericId: string,
+          @Query('invalidNumericId', {
+            type: 'string',
+            pattern: /^\d{5}$/
+          })
+          invalidNumericId: string
+        ) {
+          return { numericId, invalidNumericId };
+        }
+      }
+
+      registerControllers(mockRouter, [TypePatternController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0].message).toBe(`Parameter 'invalidNumericId' does not match pattern: /^\\d{5}$/`);
+    });
+
+    it('should correctly validate patterns with existing validation options', async () => {
+      mockReq.query = {
+        email: 'test@example.com',
+        value: '25'
+      };
+
+      @Controller('/validation')
+      class CombinedValidationController {
+        @Get('/combined')
+        testCombined(
+          @Query('email', {
+            pattern: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+            required: true
+          })
+          email: string,
+          @Query('value', {
+            type: 'number',
+            min: 10,
+            max: 100,
+            pattern: /^[1-9][0-9]$/ // Must be 10-99
+          })
+          value: number
+        ) {
+          return { email, value };
+        }
+      }
+
+      registerControllers(mockRouter, [CombinedValidationController]);
+      const [, ...handlers] = mockRouter.get.mock.calls[0];
+      const routeHandler = handlers[handlers.length - 1];
+
+      await routeHandler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockRes.json).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        value: 25
+      });
     });
   });
 });


### PR DESCRIPTION
- Changed Logger type from pino.Logger to PinoLogger for consistency.
- Modified setupLogger to accept an optional isGlobal parameter, allowing for more flexible logger initialization.
- Reintroduced serializers in the logger setup for improved logging structure.
- Updated getLogger to return a fresh logger instance when newInstance is true, enhancing request handling.
- Adjusted the global logger initialization to be conditional based on the isGlobal parameter.

test(decorator): add comprehensive parameter options tests

- Introduced a new test suite for parameter options in decorators.
- Implemented tests for various parameter types including string, number, boolean, array, and object.
- Added tests for default values, required parameters, custom validation, and transformation functions.
- Ensured robust handling of edge cases, null values, and direct array inputs.
- Included tests for extracting headers using the @ReqHeader decorator with case insensitivity.